### PR TITLE
simple test for linker

### DIFF
--- a/Test.hs
+++ b/Test.hs
@@ -1,0 +1,8 @@
+import Numerical.OpenBLAS.FFI
+
+import Foreign.C.Types
+
+main :: IO ()
+main = do
+  -- Just test that the symbol resolves
+  openblas_set_num_threads_ffi 1

--- a/hOpenBLAS.cabal
+++ b/hOpenBLAS.cabal
@@ -70,3 +70,9 @@ library
   -- Base language which the package is written in.
   default-language:    Haskell2010
   
+Test-Suite test
+    type:                exitcode-stdio-1.0
+    main-is:             Test.hs
+    build-depends:       base
+    default-language:    Haskell2010
+    build-depends:       hOpenBLAS == 0.1.0.0


### PR DESCRIPTION
Test case for symbols not being linked for "library" build. 

```
Linking dist/build/test/test ...
dist/build/test/test-tmp/Main.o:(.text+0x27): undefined reference to `openblas_set_num_threads'
collect2: error: ld returned 1 exit status
```

Initial thought was `Ghc-Options: -static -optl-pthread -optl-static` would fix this, but this it doesn't link for reasons for I don't understand yet.
