### PR TITLE
use `pkgconfig-depends` instead of `extra-libraries`

### DIFF
--- a/hblas.cabal
+++ b/hblas.cabal
@@ -135,23 +135,23 @@ library
 
 
   if flag(OpenBLAS)
-    extra-libraries: openblas pthread
+    pkgconfig-depends: openblas-threaded
 
   if flag(OpenBLAS)&& os(OSX)
     extra-lib-dirs: /usr/local/lib
 
   if os(OSX)&&!flag(OpenBLAS)
-      frameworks: Accelerate
-      -- extra-libraries: cblas lapack
+    frameworks: Accelerate
+    -- pkgconfig-depends: cblas, lapack
 
   if os(windows) && !flag(OpenBLAS)
-      extra-libraries: blas lapack
+    pkgconfig-depends: blas, lapack
 
   if !os(windows)&& !os(OSX) && !flag(OpenBLAS)
-    extra-libraries: blas lapack
+    pkgconfig-depends: blas, lapack
 
   if flag(CBLAS)
-    extra-libraries: cblas
+    pkgconfig-depends: cblas
 
 
 


### PR DESCRIPTION
`pkgconfig-depends` works better on many systems and allows automatic usage of OpenBLAS when it is installed in `pkg-config` as `blas`
