### PR TITLE
Change &&! -> && !

### DIFF
--- a/hblas.cabal
+++ b/hblas.cabal
@@ -142,17 +142,17 @@ library
   if flag(OpenBLAS)
     extra-libraries: openblas pthread
 
-  if flag(OpenBLAS)&& os(OSX)
+  if flag(OpenBLAS) && os(OSX)
     extra-lib-dirs: /usr/local/lib
 
-  if os(OSX)&&!flag(OpenBLAS)
+  if os(OSX) && !flag(OpenBLAS)
       frameworks: Accelerate
       -- extra-libraries: cblas lapack
 
   if os(windows) && !flag(OpenBLAS)
       extra-libraries: blas lapack
 
-  if !os(windows)&& !os(OSX) && !flag(OpenBLAS)
+  if !os(windows) && !os(OSX) && !flag(OpenBLAS)
     -- extra-libraries: blas lapack
     extra-libraries: blas, lapack
 


### PR DESCRIPTION
Cabal-2.2 will be stricter about parsing operators.